### PR TITLE
Changed to use jsx:decode

### DIFF
--- a/src/restc.erl
+++ b/src/restc.erl
@@ -161,7 +161,7 @@ parse_response({error, Type}) ->
 parse_body([], Body)                 -> Body;
 parse_body(_, [])                    -> [];
 parse_body(_, <<>>)                  -> [];
-parse_body("application/json", Body) -> jsx:to_term(Body);
+parse_body("application/json", Body) -> jsx:decode(Body);
 parse_body("application/xml", Body)  ->
     {ok, Data, _} = erlsom:simple_form(binary_to_list(Body)),
     Data;


### PR DESCRIPTION
Sorry if this is a repeat, I received an error page at the last step.

jsx:to_term was deprecated and removed.