### PR TITLE
Fix dependency URIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ PROJECT = restc
 # Dependecies ##########################################################
 DEPS = hackney jsx erlsom mochiweb_util
 
-dep_hackney       = git git@github.com:benoitc/hackney.git     1.3.2
-dep_jsx           = git git@github.com:talentdeficit/jsx.git   v2.6.1
-dep_erlsom        = git git@github.com:willemdj/erlsom.git     master
-dep_mochiweb_util = git git@github.com:kivra/mochiweb_util.git master
+dep_hackney       = git https://github.com/benoitc/hackney     1.3.2
+dep_jsx           = git https://github.com/talentdeficit/jsx   v2.6.1
+dep_erlsom        = git https://github.com/willemdj/erlsom     master
+dep_mochiweb_util = git https://github.com/kivra/mochiweb_util master
 
 # Standard targets #####################################################
 include erlang.mk


### PR DESCRIPTION
The git@ URIs require the user to be logged in to Github to fetch
dependencies. Make them HTTP to avoid this.