### PR TITLE
Keep calm and let it crash

### DIFF
--- a/src/restc.erl
+++ b/src/restc.erl
@@ -167,9 +167,7 @@ encode_body(json, Body) ->
 encode_body(percent, Body) ->
     mochiweb_util:urlencode(Body);
 encode_body(xml, Body) ->
-    lists:flatten(xmerl:export_simple(Body, xmerl_xml));
-encode_body(_, Body) ->
-    encode_body(?DEFAULT_ENCODING, Body).
+    lists:flatten(xmerl:export_simple(Body, xmerl_xml)).
 
 urlunsplit(S, N, P, Query) ->
     Q = mochiweb_util:urlencode(Query),

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -37,7 +37,7 @@
 -export([construct_url/2]).
 -export([construct_url/3]).
 
--type method()       :: binary | head | get | put | patch | post | trace | options | delete.
+-type method()       :: head | get | put | patch | post | trace | options | delete.
 -type url()          :: binary() | string().
 -type headers()      :: [header()].
 -type header()       :: {binary(), binary()}.

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -154,7 +154,7 @@ do_request(put, Type, Url, Headers, Body, Options) ->
 do_request(patch, Type, Url, Headers, Body, Options) ->
     Body2 = encode_body(Type, Body),
     hackney:request(patch, Url, Headers, Body2, Options);
-do_request(Method, _, Url, Headers, _, Options) ->
+do_request(Method, _, Url, Headers, _, Options) when is_atom(Method) ->
     hackney:request(Method, Url, Headers, [], Options).
 
 check_expect(_Status, []) ->


### PR DESCRIPTION
* Fixes a problem where the body is silently removed if the method is a binary
* Keep calm and let it crash, no reason to assume content type if specified incorrectly
* Removes `binary` as a valid method, it's probably a typo for `binary()` but that is neither supported.