### PR TITLE
Don't override Accept and Content-Type headers when provided by the client

### DIFF
--- a/src/restc.app.src
+++ b/src/restc.app.src
@@ -25,7 +25,7 @@
 %%
 %% ----------------------------------------------------------------------------
 {application, restc, [ {description,  "Erlang Rest Client"}
-                     , {vsn,          "0.6.0"}
+                     , {vsn,          "0.7.0"}
                      , {applications, [ kernel
                                       , stdlib
                                       , asn1

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -79,25 +79,25 @@
 
 -spec request(Url::url()) -> Response::response().
 request(Url) ->
-    request(get, ?DEFAULT_ENCODING, Url, [], [], [], []).
+    request(get, Url).
 
 -spec request(Method::method(), Url::url()) -> Response::response().
 request(Method, Url) ->
-    request(Method, ?DEFAULT_ENCODING, Url, [], [], [], []).
+    request(Method, Url, []).
 
 -spec request(Method::method(), Url::url(), Expect::status_codes()) -> Response::response().
 request(Method, Url, Expect) ->
-    request(Method, ?DEFAULT_ENCODING, Url, Expect, [], [], []).
+    request(Method, ?DEFAULT_ENCODING, Url, Expect).
 
 -spec request(Method::method(), Type::content_type(), Url::url(),
               Expect::status_codes()) -> Response::response().
 request(Method, Type, Url, Expect) ->
-    request(Method, Type, Url, Expect, [], [], []).
+    request(Method, Type, Url, Expect, []).
 
 -spec request(Method::method(), Type::content_type(), Url::url(),
               Expect::status_codes(), Headers::headers()) -> Response::response().
 request(Method, Type, Url, Expect, Headers) ->
-    request(Method, Type, Url, Expect, Headers, [], []).
+    request(Method, Type, Url, Expect, Headers, []).
 
 -spec request(Method::method(), Type::content_type(), Url::url(),
               Expect::status_codes(), Headers::headers(), Body::body()) -> Response::response().
@@ -106,12 +106,10 @@ request(Method, Type, Url, Expect, Headers, Body) ->
 
 -spec request(Method::method(), Type::content_type(), Url::url(),
     Expect::status_codes(), Headers::headers(), Body::body(), Options::options()) -> Response::response().
-request(Method, Type, Url, Expect, Headers, Body, Options) ->
-    AccessType = get_accesstype(Type),
-    Headers1 = [{<<"Accept">>, <<AccessType/binary, ", */*;q=0.9">>} | Headers],
-    Headers2 = [{<<"Content-Type">>, get_ctype(Type)} | Headers1],
+request(Method, Type, Url, Expect, Headers0, Body, Options) ->
+    Headers = lists:usort([ accept(Headers0, Type), content_type(Headers0, Type) | Headers0]),
     Retries = proplists:get_value(retries, Options, 0),
-    request_loop(Method, Type, Url, Expect, Headers2, Body, Options, Retries).
+    request_loop(Method, Type, Url, Expect, Headers, Body, Options, Retries).
 
 request_loop(Method, Type, Url, Expect, Headers, Body, Options, Retries) ->
     Response = parse_response(do_request(Method, Type, Url, Headers, Body, Options)),
@@ -151,6 +149,24 @@ construct_url(SchemeNetloc, Path, Query) when is_list(SchemeNetloc),
     urlunsplit(S, N, P, Query).
 
 %%% INTERNAL ===================================================================
+accept(Headers, Type) ->
+    case lists:keyfind(<<"Accept">>, 1, Headers) of
+        {<<"Accept">>, Accept} -> {<<"Accept">>, Accept};
+        false -> default_accept(Type)
+    end.
+
+default_accept(Type) ->
+    AccessType = get_accesstype(Type),
+    {<<"Accept">>, <<AccessType/binary, ", */*;q=0.9">>}.
+
+content_type(Headers, Type) ->
+        case lists:keyfind(<<"Content-Type">>, 1, Headers) of
+        {<<"Content-Type">>, ContentType} -> {<<"Content-Type">>, ContentType};
+        false -> default_content_type(Type)
+    end.
+
+default_content_type(Type) ->
+    {<<"Content-Type">>, get_ctype(Type)}.
 
 do_request(post, Type, Url, Headers, Body, Options) ->
     Body2 = encode_body(Type, Body),
@@ -236,4 +252,3 @@ get_ctype(json)    -> <<"application/json">>;
 get_ctype(xml)     -> <<"application/xml">>;
 get_ctype(percent) -> <<"application/x-www-form-urlencoded">>;
 get_ctype(_)       -> get_ctype(?DEFAULT_ENCODING).
-


### PR DESCRIPTION
Changes:
- Don't pass defaults from `request/[1-6]` straight into `request/7` but cascade them through the arities until eventually reaching `request/7`
- Don't add default `Accept` and `Content-Type` if provided by the client. This to avoid setting multiple headers which gets particularly awkward in the case of `Accept` header where two headers of which the default contains a `*/*` essentially nullifies the `Accept` header provided by the client. 