### PR TITLE
Support integers and atoms in body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _build
 *.crashdump
 *.beam
 .elvis
+.rebar3

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -213,14 +213,14 @@ default_content_type(Type) ->
   {<<"content-type">>, get_ctype(Type)}.
 
 do_request(post, Type, Url, Headers, Body, Options) ->
-  Body2 = restc_body:encode(Type, Body),
-  hackney:request(post, Url, Headers, Body2, Options);
+  EncodedBody = restc_body:encode(Type, Body),
+  hackney:request(post, Url, Headers, EncodedBody, Options);
 do_request(put, Type, Url, Headers, Body, Options) ->
-  Body2 = restc_body:encode(Type, Body),
-  hackney:request(put, Url, Headers, Body2, Options);
+  EncodedBody = restc_body:encode(Type, Body),
+  hackney:request(put, Url, Headers, EncodedBody, Options);
 do_request(patch, Type, Url, Headers, Body, Options) ->
-  Body2 = restc_body:encode(Type, Body),
-  hackney:request(patch, Url, Headers, Body2, Options);
+  EncodedBody = restc_body:encode(Type, Body),
+  hackney:request(patch, Url, Headers, EncodedBody, Options);
 do_request(Method, _, Url, Headers, _, Options) when is_atom(Method) ->
   hackney:request(Method, Url, Headers, [], Options).
 

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -175,9 +175,9 @@ construct_url(BaseUrl, Path, Query) ->
                     Query::querys(),
                     Options::[option()]) -> Url::url().
 construct_url(BaseUrl, Path, Query, Options) ->
-  BaseUrlBin = to_binary(BaseUrl),
-  PathBin    = to_binary(Path),
-  QueryBin   = lists:map(fun({K,V}) -> {to_binary(K), to_binary(V)} end, Query),
+  BaseUrlBin = s_to_binary(BaseUrl),
+  PathBin    = s_to_binary(Path),
+  QueryBin   = lists:map(fun({K,V}) -> {s_to_binary(K), s_to_binary(V)} end, Query),
   UrlBin     = hackney_url:make_url(BaseUrlBin, PathBin, QueryBin),
   case Options of
     [return_binary] -> UrlBin;
@@ -186,8 +186,13 @@ construct_url(BaseUrl, Path, Query, Options) ->
 
 %%% INTERNAL ===================================================================
 
-to_binary(V) when is_binary(V) -> V;
-to_binary(V) when is_list(V)   -> list_to_binary(V).
+%% Convert from string() to binary()
+s_to_binary(V) when is_binary(V) -> V;
+s_to_binary(V) when is_list(V)   -> list_to_binary(V).
+
+to_binary(V) when is_integer(V) -> integer_to_binary(V);
+to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
+to_binary(V)                    -> s_to_binary(V).
 
 normalize_headers(Headers) ->
   lists:map(fun({Key, Val}) ->

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -175,10 +175,10 @@ construct_url(BaseUrl, Path, Query) ->
                     Query::querys(),
                     Options::[option()]) -> Url::url().
 construct_url(BaseUrl, Path, Query, Options) ->
-  BaseUrlBin = s_to_binary(BaseUrl),
-  PathBin    = s_to_binary(Path),
+  BaseUrlBin = string_to_binary(BaseUrl),
+  PathBin    = string_to_binary(Path),
   QueryBin   = lists:map(fun({K,V}) ->
-                             {s_to_binary(K), s_to_binary(V)}
+                             {string_to_binary(K), string_to_binary(V)}
                          end, Query),
   UrlBin     = hackney_url:make_url(BaseUrlBin, PathBin, QueryBin),
   case Options of
@@ -188,13 +188,12 @@ construct_url(BaseUrl, Path, Query, Options) ->
 
 %%% INTERNAL ===================================================================
 
-%% Convert from string() to binary()
-s_to_binary(V) when is_binary(V) -> V;
-s_to_binary(V) when is_list(V)   -> list_to_binary(V).
+string_to_binary(V) when is_binary(V) -> V;
+string_to_binary(V) when is_list(V)   -> list_to_binary(V).
 
 to_binary(V) when is_integer(V) -> integer_to_binary(V);
 to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
-to_binary(V)                    -> s_to_binary(V).
+to_binary(V)                    -> string_to_binary(V).
 
 normalize_headers(Headers) ->
   lists:map(fun({Key, Val}) ->

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -177,7 +177,9 @@ construct_url(BaseUrl, Path, Query) ->
 construct_url(BaseUrl, Path, Query, Options) ->
   BaseUrlBin = s_to_binary(BaseUrl),
   PathBin    = s_to_binary(Path),
-  QueryBin   = lists:map(fun({K,V}) -> {s_to_binary(K), s_to_binary(V)} end, Query),
+  QueryBin   = lists:map(fun({K,V}) ->
+                             {s_to_binary(K), s_to_binary(V)}
+                         end, Query),
   UrlBin     = hackney_url:make_url(BaseUrlBin, PathBin, QueryBin),
   case Options of
     [return_binary] -> UrlBin;

--- a/src/restc_body.erl
+++ b/src/restc_body.erl
@@ -1,0 +1,22 @@
+-module(restc_body).
+
+-export([encode/2, decode/2]).
+
+encode(json, Body) ->
+  jsx:encode(Body);
+encode(percent, Body) ->
+  lists:map(fun({K, V}) ->
+                {restc_util:to_binary(K), restc_util:to_binary(V)}
+            end, Body),
+  binary_to_list(hackney_url:qs(Body, []));
+encode(xml, Body) ->
+  lists:flatten(xmerl:export_simple(Body, xmerl_xml)).
+
+decode(_, <<>>)                      -> [];
+decode(<<"application/json">>, Body) -> jsx:decode(Body);
+decode(<<"application/xml">>, Body)  ->
+  {ok, Data, _} = erlsom:simple_form(binary_to_list(Body)),
+  Data;
+decode(<<"text/xml">>, Body)  -> decode(<<"application/xml">>, Body);
+decode(<<"image/png">>, Body) -> Body;
+decode(_, Body)               -> Body.

--- a/src/restc_util.erl
+++ b/src/restc_util.erl
@@ -1,0 +1,10 @@
+-module(restc_util).
+
+-export([string_to_binary/1, to_binary/1]).
+
+string_to_binary(V) when is_binary(V) -> V;
+string_to_binary(V) when is_list(V)   -> list_to_binary(V).
+
+to_binary(V) when is_integer(V) -> integer_to_binary(V);
+to_binary(V) when is_atom(V)    -> atom_to_binary(V, utf8);
+to_binary(V)                    -> string_to_binary(V).

--- a/test/prop_restc_body.erl
+++ b/test/prop_restc_body.erl
@@ -1,0 +1,21 @@
+-module(prop_restc_body).
+-include_lib("proper/include/proper.hrl").
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+prop_decode_encode_json() ->
+    ?FORALL(Obj, object_proplist(),
+            Obj =:= restc_body:decode(<<"application/json">>, restc_body:encode(json, Obj))).
+
+%%%%%%%%%%%%%%%%%%
+%%% Generators %%%
+%%%%%%%%%%%%%%%%%%
+object_proplist() ->
+    list({key(), value()}).
+
+key() ->
+    utf8().
+
+value() ->
+    oneof([utf8(), integer()]).

--- a/test/prop_restc_body.erl
+++ b/test/prop_restc_body.erl
@@ -6,7 +6,8 @@
 %%%%%%%%%%%%%%%%%%
 prop_decode_encode_json() ->
     ?FORALL(Obj, object_proplist(),
-            Obj =:= restc_body:decode(<<"application/json">>, restc_body:encode(json, Obj))).
+            Obj =:= restc_body:decode(<<"application/json">>,
+                                      restc_body:encode(json, Obj))).
 
 %%%%%%%%%%%%%%%%%%
 %%% Generators %%%


### PR DESCRIPTION
Even though in the query string we want to force clients to convert to string, in the body since we also support atoms/integers we should also allow for percent encoded body