### PR TITLE
Add `jsx` to `.app.src` to include it in release builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ function for working with urls and query parameters.
 
 Include restclient as a rebar dependency with:
 
-	{deps, [{restc, ".*", {git, "git://github.com/kivra/restclient.git", {tag, "0.8.0"}}}]}.
+	{deps, [{restc, ".*", {git, "git://github.com/kivra/restclient.git", {tag, "0.8.2"}}}]}.
 
 You have to start inets before using the client and if you want to use https make sure to start ssl before.
 Then you can use the client as:

--- a/src/restc.app.src
+++ b/src/restc.app.src
@@ -25,7 +25,7 @@
 %%
 %% ----------------------------------------------------------------------------
 {application, restc, [ {description,  "Erlang Rest Client"}
-                     , {vsn,          "0.8.1"}
+                     , {vsn,          "0.8.2"}
                      , {applications, [ kernel
                                       , stdlib
                                       , asn1
@@ -33,6 +33,7 @@
                                       , public_key
                                       , ssl
                                       , hackney
+                                      , jsx
                                       ]}
                      , {env,          []}
                      , {registered,   []}


### PR DESCRIPTION
While using this library (via `slackerl`) I found crash logs in production
with `{undef,[{jsx,decode,...` indicating the `jsx` isn't present. Sure enough
it wasn't included in the release `lib/` directory because nothing was requiring it.

In this patch I'm adding the dependency into the `.app.src` list of applications so
that it will be properly included in releases and initialize if it needs to. This was
hidden at dev time because the library was available locally.

I've added a patch-level version bump since this is fixing what I believe is a simple
bug and leaving all behaviors and interfaces otherwise untouched.