### PR TITLE
Fix percent encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 compile_elvis:
-	git clone https://github.com/inaka/elvis.git --branch 0.5.0 --single-branch .elvis && \
+	git clone https://github.com/inaka/elvis.git --branch 1.0.1 --single-branch .elvis && \
 	cd .elvis && \
 	rebar3 compile && \
 	rebar3 escriptize && \

--- a/elvis.config
+++ b/elvis.config
@@ -1,77 +1,66 @@
 %% -*- erlang -*-
-[ {elvis,
-   [ {config,
-      [ #{dirs => [ "src/*"
-                  , "src"
-                  ],
-          filter => "*.erl",
-          ignore => [],
-          rules => [ {elvis_style, line_length,
-                      #{ limit => 80,
-                         skip_comments => false
-                       }}
-                   , {elvis_style, no_tabs}
-                   , {elvis_style, no_trailing_whitespace}
-                   , {elvis_style, macro_module_names}
-                   , {elvis_style, nesting_level,
-                      #{ level => 3,
-                         ignore => [
-                                   ]
-                       }}
-                   , {elvis_style, god_modules,
-                      #{ limit => 25,
-                         ignore => [
-                                   ]
-                       }}
-                   , {elvis_style, no_nested_try_catch,
-                      #{ignore => [
-                                  ]
-                       }}
-                   , {elvis_style, invalid_dynamic_call,
-                      #{ignore => [
-                                  ]
-                       }}
-                   , {elvis_style, used_ignored_variable}
-                   , {elvis_style, no_behavior_info}
-                   , {elvis_style, module_naming_convention,
-                      #{ ignore => [],
-                         regex => "^([a-z][a-z0-9]*_?)([a-z0-9]*_?)*$"
-                       }}
-                   , {elvis_style, function_naming_convention,
-                      #{ regex => "^([a-z][a-z0-9]*_?)([a-z0-9]*_?)*$"
-                       }}
-                   , {elvis_style, variable_naming_convention,
-                      #{ regex => "^_?([A-Z][0-9a-zA-Z_]*)$"
-                       }}
-                   , {elvis_style, state_record_and_type}
-                   , {elvis_style, no_spec_with_records}
-                   , {elvis_style, dont_repeat_yourself,
-                      #{ min_complexity => 25,
-                         ignore => [
-                                   ]
-                       }}
-                   ]
-         },
-        #{dirs => [ "test"
-                  ],
-          filter => "*.erl",
-          rules => [ {elvis_style, line_length,
-                      #{ limit => 100,
-                         skip_comments => false
-                       }}
-                   , {elvis_style, no_tabs}
-                   , {elvis_style, no_trailing_whitespace}
-                   , {elvis_style, macro_module_names}
-                   , {elvis_style, no_debug_call,
-                      #{ignore => [
-                                  ]
-                       }}
-                   ]
-         }
-      ]
-     }
-   ]
-  }
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["src"],
+                filter => "*.erl",
+                ruleset => erl_files,
+                ignore => [],
+                rules => [
+                    {elvis_text_style, line_length, #{
+                        limit => 80,
+                        skip_comments => false
+                    }},
+                    {elvis_text_style, no_tabs},
+                    {elvis_text_style, no_trailing_whitespace},
+                    {elvis_style, macro_module_names},
+                    {elvis_style, nesting_level, #{
+                        level => 3,
+                        ignore => []
+                    }},
+                    {elvis_style, god_modules, #{
+                        limit => 25,
+                        ignore => []
+                    }},
+                    {elvis_style, no_nested_try_catch, #{ignore => []}},
+                    {elvis_style, invalid_dynamic_call, #{ignore => []}},
+                    {elvis_style, used_ignored_variable},
+                    {elvis_style, no_behavior_info},
+                    {elvis_style, module_naming_convention, #{
+                        ignore => [],
+                        regex => "^([a-z][a-z0-9]*_?)([a-z0-9]*_?)*$"
+                    }},
+                    {elvis_style, function_naming_convention, #{
+                        regex => "^([a-z][a-z0-9]*_?)([a-z0-9]*_?)*$"
+                    }},
+                    {elvis_style, variable_naming_convention, #{
+                        regex => "^_?([A-Z][0-9a-zA-Z_]*)$"
+                    }},
+                    {elvis_style, state_record_and_type},
+                    {elvis_style, no_spec_with_records},
+                    {elvis_style, dont_repeat_yourself, #{
+                        min_complexity => 25,
+                        ignore => []
+                    }}
+                ]
+            },
+            #{
+                dirs => ["test"],
+                filter => "*.erl",
+                rules => [
+                    {elvis_text_style, line_length, #{
+                        limit => 100,
+                        skip_comments => false
+                    }},
+                    {elvis_text_style, no_tabs},
+                    {elvis_text_style, no_trailing_whitespace},
+                    {elvis_style, macro_module_names},
+                    {elvis_style, no_debug_call, #{ignore => []}}
+                ]
+            }
+        ]}
+    ]}
 ].
 
 %%%_* Emacs ====================================================================

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,12 @@
         {erlsom,"1.5.0"}
        ]}.
 
-{project_plugins, [rebar3_proper]}.
+{project_plugins, [rebar3_proper, erlfmt]}.
+
+{erlfmt, [
+    write,
+    {print_width, 80}  % same as in elvis.config
+]}.
 
 {profiles,
     [{test, [

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -179,7 +179,7 @@ construct_url(BaseUrl, Path, Query) ->
 construct_url(BaseUrl, Path, Query, Options) ->
   BaseUrlBin = string_to_binary(BaseUrl),
   PathBin    = string_to_binary(Path),
-  QueryBin   = lists:map(fun({K,V}) ->
+  QueryBin   = lists:map(fun({K, V}) ->
                              {string_to_binary(K), string_to_binary(V)}
                          end, Query),
   UrlBin     = hackney_url:make_url(BaseUrlBin, PathBin, QueryBin),

--- a/src/restc_body.erl
+++ b/src/restc_body.erl
@@ -3,27 +3,38 @@
 -export([encode/2, decode/3]).
 
 encode(json, Body) ->
-  jsx:encode(Body);
+    jsx:encode(Body);
+encode(percent, Body) when is_map(Body) ->
+    hackney_url:qs(maps:to_list(Body), []);
 encode(percent, Body) ->
-  lists:map(fun({K, V}) ->
-                {restc_util:to_binary(K), restc_util:to_binary(V)}
-            end, Body),
-  binary_to_list(hackney_url:qs(Body, []));
+    hackney_url:qs(Body, []);
 encode(xml, Body) ->
-  lists:flatten(xmerl:export_simple(Body, xmerl_xml)).
+    lists:flatten(xmerl:export_simple(Body, xmerl_xml)).
 
-decode(_, <<>>, _Opts)                      -> [];
-decode(<<"application/json">>, Body, Opts0)  ->
-  Opts =
-    case lists:member(return_maps, Opts0) of
-      true -> [return_maps];
-      false -> []
-    end,
-  jsx:decode(Body, Opts);
-decode(<<"application/xml">>, Body, _Opts)  ->
-  {ok, Data, _} = erlsom:simple_form(binary_to_list(Body)),
-  Data;
-decode(<<"text/xml">>, Body, Opts)   ->
-  decode(<<"application/xml">>, Body, Opts);
-decode(<<"image/png">>, Body, _Opts) -> Body;
-decode(_, Body, _Opts)               -> Body.
+decode(_, <<>>, Opts) ->
+    case proplists:get_bool(return_maps, Opts) of
+        true -> #{};
+        _ -> []
+    end;
+decode(<<"application/json">>, Body, Opts0) ->
+    Opts =
+        case lists:member(return_maps, Opts0) of
+            true -> [return_maps];
+            false -> []
+        end,
+    jsx:decode(Body, Opts);
+decode(<<"application/xml">>, Body, _Opts) ->
+    {ok, Data, _} = erlsom:simple_form(binary_to_list(Body)),
+    Data;
+decode(<<"text/xml">>, Body, Opts) ->
+    decode(<<"application/xml">>, Body, Opts);
+decode(<<"image/png">>, Body, _Opts) ->
+    Body;
+decode(<<"application/x-www-form-urlencoded">>, Body, Opts) ->
+    KeyValueList = hackney_url:parse_qs(Body),
+    case proplists:get_bool(return_maps, Opts) of
+        true -> maps:from_list(KeyValueList);
+        _ -> KeyValueList
+    end;
+decode(_, Body, _Opts) ->
+    Body.

--- a/test/prop_restc_body.erl
+++ b/test/prop_restc_body.erl
@@ -1,22 +1,67 @@
+%%% @doc Verifies that encoding/decoding results in the same value.
+%%%
+%%% To make it a bit easier to test this only tests non-empty binary keys and
+%%% values, as percent encoding changes the output otherwise (as it should).
+%%% @end
 -module(prop_restc_body).
 -include_lib("proper/include/proper.hrl").
 
-%%%%%%%%%%%%%%%%%%
-%%% Properties %%%
-%%%%%%%%%%%%%%%%%%
-prop_decode_encode_json() ->
-    ?FORALL(Obj, object_proplist(),
-            Obj =:= restc_body:decode(<<"application/json">>,
-                                      restc_body:encode(json, Obj), [])).
+prop_json_as_maps() ->
+    ?FORALL(
+        Object,
+        object(),
+        Object =:=
+            restc_body:decode(
+                <<"application/json">>,
+                restc_body:encode(json, Object),
+                [return_maps]
+            )
+    ).
+
+prop_json_as_proplists() ->
+    ?FORALL(
+        Object,
+        proplist(),
+        Object =:=
+            restc_body:decode(
+                <<"application/json">>,
+                restc_body:encode(json, Object),
+                []
+            )
+    ).
+
+prop_percent_as_maps() ->
+    ?FORALL(
+        Object,
+        object(),
+        Object =:=
+            restc_body:decode(
+                <<"application/x-www-form-urlencoded">>,
+                restc_body:encode(percent, Object),
+                [return_maps]
+            )
+    ).
+
+prop_percent_as_proplists() ->
+    ?FORALL(
+        Object,
+        proplist(),
+        Object =:=
+            restc_body:decode(
+                <<"application/x-www-form-urlencoded">>,
+                restc_body:encode(percent, Object),
+                []
+            )
+    ).
 
 %%%%%%%%%%%%%%%%%%
 %%% Generators %%%
 %%%%%%%%%%%%%%%%%%
-object_proplist() ->
-    list({key(), value()}).
+object() ->
+    map(non_empty_text(), non_empty_text()).
 
-key() ->
-    utf8().
+proplist() ->
+    list({non_empty_text(), non_empty_text()}).
 
-value() ->
-    oneof([utf8(), integer()]).
+non_empty_text() ->
+    non_empty(utf8()).

--- a/test/restc_SUITE.erl
+++ b/test/restc_SUITE.erl
@@ -153,7 +153,7 @@ type_is_json__making_request__sends_json_encoded_body(_Config) ->
 type_is_percent__making_request__sends_percent_encoded_body(_Config) ->
   mock_hackney_success(200),
   Body = [{<<"any">>, <<"data">>}],
-  ExpectedBody = mochiweb_util:urlencode(Body),
+  ExpectedBody = list_to_binary(mochiweb_util:urlencode(Body)),
 
   restc:request(post, percent, <<"http://any_url.com">>, [200], [], Body),
 


### PR DESCRIPTION
The JSON encoder, jsx, already handles maps. This reaches feature parity with the jsx encoder/decoder. However, it turns out there's a few other discrepencies between maps and proplists, which this also fixes. Finally this makes the percent encode, like jsx, return a binary instead of a list.

To verify this does what you think it does, this also enables and expands the existing PropEr test. It turns out the code was there, but not hook up to either EUnit or CT. Now it does.

---

This also fixes Elvis, as 0.5.0 no longer compiles on OTP 24. This upgrades it and updates the config accordingly. Also fixes a missing space Elvis then found.