### PR TITLE
Fix `dialyzer`ing for OTP 27

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,3 +23,5 @@
               deprecated_function_calls,deprecated_functions]}.
 
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.
+
+{dialyzer, [{plt_extra_apps, [xmerl, erlsom]}]}.

--- a/src/restc.erl
+++ b/src/restc.erl
@@ -59,7 +59,7 @@
 -type content_type() :: multi | json | xml | percent | png.
 -type body()         :: binary()             |
                         jsx:json_term()      |
-                        erlsom:simple_form() |
+                        term() | % check erlsom:simple_form/1,2
                         multi_body().
 -type multi_part()   :: {Name::binary(), Value::binary()} |
                         { file


### PR DESCRIPTION
## Motivation

We have an internal dependency that uses this lib. and it's failing `dialyzer` analysis.

## Further considerations

`{dialyzer, [{plt_extra_apps, [xmerl, erlsom]}]}.` is required because otherwise the applications aren't loaded for analysis (if e.g. they were in `.app.src` this wouldn't be required).