### PR TITLE
fix: erlsom missing as a dep in restc.app.src

### DIFF
--- a/src/restc.app.src
+++ b/src/restc.app.src
@@ -34,6 +34,7 @@
                                       , ssl
                                       , hackney
                                       , jsx
+                                      , erlsom
                                       ]}
                      , {env,          []}
                      , {registered,   []}


### PR DESCRIPTION
`erlsom` is a dependency, it's in `rebar.config` and `restc_body.erl` uses `erlsom`. Hence we want this fix.

Related fix:
* https://github.com/kivra/kivra_core/pull/5722

And why this came up now:
* https://github.com/kivra/kivra_core/pull/5720/commits/9ad2b62a835ac6401d366854139d72d187ab92cf
* https://github.com/kivra/kivra_core/pull/5720

Some issues in production kind of related to this (in combination with my commit above):
* https://kivra.sentry.io/issues/87892999/?environment=production&project=4510046267637840